### PR TITLE
Create relative symlinks rather than absolute

### DIFF
--- a/cronicle/__init__.py
+++ b/cronicle/__init__.py
@@ -99,7 +99,7 @@ def timed_symlink(filename, ffolder, cfg):
         if not path.exists(target_dir):
             makedirs(target_dir)
         logger.info('Creating symlink %s' % target)
-        symlink(filename, target)
+        symlink(path.join('..', path.basename(filename)), target)
     else:
         logger.error('%s already exists' % target)
         return


### PR DESCRIPTION
I assume this change should be okay, since the frequency-folders are assumed to be directly under the target directory.

This makes it easier to use with Docker, because I can mount the target directory at an arbitrary location in the container, and still have the symlinks work on the host.