### PR TITLE
Update Dockerfile for README.rst (and also simplify)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,13 @@
 FROM python:3.7-alpine
 
-RUN mkdir -p /cronicle/cronicle
-
-COPY requirements.txt /cronicle
-RUN pip install --requirement /cronicle/requirements.txt
-
-COPY cronicle /cronicle/cronicle
-COPY *.py README.md /cronicle/
-
 WORKDIR /cronicle
+
+COPY requirements.txt ./
+RUN pip install --requirement requirements.txt
+
+COPY ./cronicle ./cronicle
+COPY *.py README.rst ./
+
 RUN python3 setup.py install
 
 ENTRYPOINT ["cronicle"]


### PR DESCRIPTION
Docker build was breaking due to README.md being replaced with README.rst. Also simplified the Dockerfile a bit.